### PR TITLE
Use ubuntu-22.04 instead of ubuntu-latest for Github Actions to resolve a GLIBC mismatch error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update_urls.yml
+++ b/.github/workflows/update_urls.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   update_urls:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ FIRESTARTER
 
 ## Building
 
-The ``build.py`` script can be used to build the ISO. It is designed to run on [ubuntu-latest](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) for GitHub actions, but you can use a Linux distro of your choice.
+The ``build.py`` script can be used to build the ISO. It is designed to run on [ubuntu-22.04](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) for GitHub actions, but you can use a Linux distro of your choice.
 
 ```bash
 git clone https://github.com/valleyofdoom/StresKit.git


### PR DESCRIPTION
Fixes https://github.com/valleyofdoom/StresKit/issues/3